### PR TITLE
Replace html base href by angular

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
+import { APP_BASE_HREF } from '@angular/common';
 
 import { AppComponent } from './app.component';
 import { UsersComponent } from './users/users.component';
@@ -25,7 +26,9 @@ import { HomeComponent } from './home/home.component';
       { path: 'users', component: UsersComponent}
     ])
   ],
-  providers: [],
+  providers: [
+    {provide: APP_BASE_HREF, useValue: '/'},
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>ReproRouter</title>
-  <base href="/">
+  <!--<base href="/">-->
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
I'm not sure it's a good solution but you can make the test run by replacing the html 
```html
<base href="/">
```
by the angular way:
```js
providers: [
    {provide: APP_BASE_HREF, useValue: '/'},
  ],
```

Inside the app.module.